### PR TITLE
differentiating even/odd lessons that are not active this week

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/parser": "^5.51.0",
         "bootstrap": "^5.1.1",
         "chalk": "^4.1.2",
+        "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
         "dotenv": "^16.0.2",
         "eslint-config-prettier": "^8.6.0",
@@ -2487,9 +2488,9 @@
       }
     },
     "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -7261,9 +7262,9 @@
       }
     },
     "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@typescript-eslint/parser": "^5.51.0",
     "bootstrap": "^5.1.1",
     "chalk": "^4.1.2",
+    "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
     "dotenv": "^16.0.2",
     "eslint-config-prettier": "^8.6.0",

--- a/src/components/Lesson.tsx
+++ b/src/components/Lesson.tsx
@@ -6,6 +6,8 @@ import { ContextualizedLesson } from './Lessons';
 import { HourWidthContext } from './TimetableWrapper';
 import { LessonIntersection } from './LessonIntersection';
 import useVictim from '../hooks/useVictim';
+import classNames from 'classnames';
+import { getEvenOddWeek } from '../utils/date';
 
 export const SEPARATOR_WHITESPACE_PERCENTAGE = 4;
 
@@ -53,9 +55,17 @@ export const Lesson = ({ dataWithCollisions }: Props) => {
   const displayInline =
     dataWithCollisions.levelCount > MINIMUM_OVERLAP_FOR_INLINE;
 
+  // if the note is "even" or "odd" and it doesn't match the current week => inactive
+  const isInActive = dataWithCollisions.note &&
+    ["even", "odd"].some(note => note === dataWithCollisions.note) &&
+    dataWithCollisions.note !== getEvenOddWeek();
+
   return (
     <div
-      className={`lesson text-dark rounded bg-${dataWithCollisions.type}`}
+      className={classNames(
+        `lesson text-dark rounded bg-${dataWithCollisions.type}`,
+        { 'is-inactive': isInActive }
+      )}
       style={{
         width: width,
         marginLeft: marL,

--- a/src/styles/Lessons.scss
+++ b/src/styles/Lessons.scss
@@ -23,8 +23,7 @@
     }
 
     &.is-inactive {
-        opacity: 0.7;
-        background-color: #666;
+        filter: brightness(0.5);
         cursor: default;
         
         .lesson-intersections {

--- a/src/styles/Lessons.scss
+++ b/src/styles/Lessons.scss
@@ -21,6 +21,16 @@
             box-shadow: none;
         }
     }
+
+    &.is-inactive {
+        opacity: 0.7;
+        background-color: #666;
+        cursor: default;
+        
+        .lesson-intersections {
+            display: none; // TODO: is gud?
+        }
+    }
 }
 
 .lesson-content {


### PR DESCRIPTION
This branch has been derived from #10 _(please review & merge the #10 PR first)_

Example with the current week being `odd`:
![image](https://user-images.githubusercontent.com/38100632/222182397-7bd0829b-d49a-4da4-9fa3-939581fec322.png)


The reason for the condition `["even", "odd"].some(note => note === dataWithCollisions.note)` is that a lesson's note may not always be "even" or "odd". Victims could maybe be allowed to provide custom notes?

And if it always will be either `"even"`, `"odd"` or `null`, then who cares, it works and doesn't break...
