### PR TITLE
visually differentiating even/odd lessons that are not active this week

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/parser": "^5.51.0",
         "bootstrap": "^5.1.1",
         "chalk": "^4.1.2",
+        "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
         "date-fns-tz": "^2.0.0",
         "dotenv": "^16.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@typescript-eslint/parser": "^5.51.0",
     "bootstrap": "^5.1.1",
     "chalk": "^4.1.2",
+    "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
     "date-fns-tz": "^2.0.0",
     "dotenv": "^16.0.2",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@vitejs/plugin-react-swc': ^3.0.0
   bootstrap: ^5.1.1
   chalk: ^4.1.2
+  classnames: ^2.3.2
   date-fns: ^2.29.3
   date-fns-tz: ^2.0.0
   dotenv: ^16.0.2
@@ -35,6 +36,7 @@ dependencies:
   '@typescript-eslint/parser': 5.54.0_jofidmxrjzhj7l6vknpw5ecvfe
   bootstrap: 5.2.3_@popperjs+core@2.11.6
   chalk: 4.1.2
+  classnames: 2.3.2
   date-fns: 2.29.3
   date-fns-tz: 2.0.0_date-fns@2.29.3
   dotenv: 16.0.3

--- a/client/src/components/Lesson.tsx
+++ b/client/src/components/Lesson.tsx
@@ -5,6 +5,8 @@ import { TIME_OFFSET_PX } from './Hour';
 import { LessonIntersection } from './LessonIntersection';
 import { ContextualizedLesson } from './Lessons';
 import { HourWidthContext } from './TimetableWrapper';
+import classNames from 'classnames';
+import { getEvenOddWeek } from '../utils/date';
 
 export const SEPARATOR_WHITESPACE_PERCENTAGE = 4;
 
@@ -48,9 +50,17 @@ export const Lesson = ({ dataWithCollisions }: Props) => {
   const displayInline =
     dataWithCollisions.levelCount > MINIMUM_OVERLAP_FOR_INLINE;
 
+  // if the note is "even" or "odd" and it doesn't match the current week => inactive
+  const isActive = !dataWithCollisions.note ||
+    !["even", "odd"].some(note => note === dataWithCollisions.note) ||
+    dataWithCollisions.note === getEvenOddWeek();
+
   return (
     <div
-      className={`lesson text-dark rounded bg-${dataWithCollisions.type}`}
+      className={classNames(
+        `lesson text-dark rounded bg-${dataWithCollisions.type}`,
+        { 'is-inactive': !isActive }
+      )}
       style={{
         width: width,
         marginLeft: marL,

--- a/client/src/styles/Lessons.scss
+++ b/client/src/styles/Lessons.scss
@@ -1,15 +1,20 @@
 .lesson {
-    transition: all var(--transition-duration) ease;
     position: relative;
     top: 0;
+    cursor: default;
+    transition: all var(--transition-duration) ease;
 
     // the default, un-hovered state
     &:not(:hover) {
         .lesson-intersections .lesson-intersection {
-            // correct translate is set inline (!important needed)
-            transform: translate3d(0,0,0) !important;
+            // "hovered" translate value is set inline by React (!important needed)
+            transform: translate3d(0, 0, 0) !important;
             box-shadow: none;
         }
+    }
+
+    &.is-inactive {
+        filter: brightness(0.4) grayscale(0.25);
     }
 }
 


### PR DESCRIPTION
This branch has been derived from #13 _(please review & merge the #13 PR first)_

Example with the current week being `odd`:
![image](https://user-images.githubusercontent.com/38100632/222417907-959e04d6-3553-43fd-9e5c-0b3e37b2b686.png)

The reason for the condition `["even", "odd"].some(note => note === dataWithCollisions.note)` is that a lesson's note may not always be "even" or "odd". Victims could be maybe allowed to provide custom notes in the future?

And if it will be always either `"even"`, `"odd"` or `null`, then who cares, it works and doesn't break...